### PR TITLE
Added 'view raw' button

### DIFF
--- a/src/pages/posts/[postid].astro
+++ b/src/pages/posts/[postid].astro
@@ -49,6 +49,7 @@ const html = sanitizeHtml(await marked.parse(content.body), {
                 {content.unlisted && <small class="unlisted">(Unlisted)</small>}
             </p>
             <TagList tags={content?.tags} />
+            <a href={new URL('raw', Astro.url)}>View Raw</a>
         </div>
         <Timestamp client:only="preact" time={content.created_at} />
     </section>

--- a/src/pages/posts/[postid]/raw.ts
+++ b/src/pages/posts/[postid]/raw.ts
@@ -1,0 +1,25 @@
+import type { APIRoute, Params, } from 'astro';
+import { supabase } from '../../../util/supabase.astro';
+
+export const GET: APIRoute = async ({params, request}:{params: Params,request:any}) => {
+    const postid = params.postid;
+    if (typeof postid === 'undefined') {
+        return new Response('What the fuck', { status: 500 });
+    }
+    const { data, error } = await supabase().from('posts').select().eq('id', postid);
+
+    if (error || data.length === 0) {
+        return new Response('Could not find requested resource', {status: 404});
+    }
+    
+    if (data.length > 1) {
+        return new Response('Huh??', {status: 500});
+    }
+    
+    const content = data[0];
+    
+    return new Response(
+        content.body,
+        {headers: {'content-type': 'text/markdown; charset=utf-8'}}
+    );
+}


### PR DESCRIPTION
Added a 'view raw' button to posts, which links to /posts/[id]/raw.

The raw view page displays the markdown content of the page before formatting is applied, for downloading or copying to clipboard.