### PR TITLE
Added search functionality, refactored how pagination works

### DIFF
--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -4,7 +4,7 @@
     </div>
     <div class="right">
         <form action="/search" id="search-form">
-            <input type="search" name="q" placeholder="Search for posts" autocomplete="off"/>
+            <input type="search" name="q" placeholder="Search for posts" autocomplete="off" aria-label="Search"/>
         </form>
         <a class="new-post" href="/new">+ new</a>
     </div>
@@ -37,15 +37,27 @@
         }
     }
 
+    .left, .right {
+        display: flex;
+        flex-direction: row;
+        align-items: stretch;
+    }
+
     .new-post {
         padding: 0.25rem 0.5rem;
         min-width: 0;
         background: var(--gradient-success);
         color: #fff;
         border-radius: 0.25rem;
+        display: flex;
+        align-items: center;
 
         &::before {
             opacity: 0;
         }
+    }
+
+    input[name="q"] {
+        margin: 0;
     }
 </style>

--- a/src/components/header.astro
+++ b/src/components/header.astro
@@ -3,6 +3,9 @@
         <a href="/" class="title"># <span class="underline">Markdum</span>p</a>
     </div>
     <div class="right">
+        <form action="/search" id="search-form">
+            <input type="search" name="q" placeholder="Search for posts" autocomplete="off"/>
+        </form>
         <a class="new-post" href="/new">+ new</a>
     </div>
 </header>
@@ -17,6 +20,7 @@
             display: flex;
             justify-content: center;
             align-items: center;
+            gap: var(--spacing-base);
         }
     }
 

--- a/src/components/pagination.astro
+++ b/src/components/pagination.astro
@@ -1,12 +1,17 @@
 ---
-const { tag, page, totalPages } = Astro.props;
+const { page, totalPages } = Astro.props;
+const getPageURL = (page:number) => {
+    const url = new URL(Astro.url);
+    url.searchParams.set('p', page.toString());
+    return url;
+}
 ---
 <div class="pagination">
-    {page > 0 && <a href={`/tagged/${tag}/0`}>&lt;&lt;</a>}
-    {page > 0 && <a href={`/tagged/${tag}/${page}`}>&lt;</a>}
+    {page > 0 && <a href={getPageURL(0)}>&lt;&lt;</a>}
+    {page > 0 && <a href={getPageURL(page)}>&lt;</a>}
     <p>Page {page + 1} / {totalPages}</p>
-    {page < totalPages - 1 && <a href={`/tagged/${tag}/${page + 2}`}>&gt;</a>}
-    {page < totalPages - 1 && <a href={`/tagged/${tag}/${totalPages}}`}>&gt;&gt;</a>}
+    {page < totalPages - 1 && <a href={getPageURL(page+2)}>&gt;</a>}
+    {page < totalPages - 1 && <a href={getPageURL(totalPages)}>&gt;&gt;</a>}
 </div>
 
 <style>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -1,0 +1,49 @@
+---
+import BaseLayout from '../layouts/base-layout.astro';
+import { supabase } from '../util/supabase.astro';
+import Pagination from '../components/pagination.astro';
+import PostList from '../components/post-list.astro';
+import Seo from '../components/seo.astro';
+
+const err = (code: number) => {
+    Astro.response.status = code;
+    Astro.response.statusText =
+        { 404: 'Not found', 500: 'Internal server error' }[code] ?? 'Error';
+    return new Response(null, Astro.response);
+};
+
+const query = Astro.url.searchParams.get('q') ?? '';
+
+const pageStr = Astro.url.searchParams.get('p') ?? '1';
+const pageIndex = (parseInt(pageStr) || 1) - 1;
+
+const RESULTS_PER_PAGE = 20;
+
+const { data: posts, error: postsError } = await supabase()
+    .from('posts')
+    .select('title, created_at, tags, id')
+    .eq('unlisted', false)
+    .ilike('title', `%${query}%`) // TODO: this is far from a robust search system
+    .order('created_at', { ascending: false })
+    .range(
+        pageIndex * RESULTS_PER_PAGE,
+        pageIndex * RESULTS_PER_PAGE + (RESULTS_PER_PAGE - 1)
+    );
+
+const { count: total } = await supabase()
+    .from('posts')
+    .select('*', { count: 'exact', head: true })
+    .eq('unlisted', false)
+    .ilike('title', `%${query}%`)
+
+const totalPages = Math.ceil((total ?? 1) / RESULTS_PER_PAGE);
+---
+
+<Seo title='Markdump' description={`Search for ${query}`} />
+<BaseLayout title={`Search "${query}"`}>
+    {query.length > 0 && <h1>Search results for "{query}"</h1>}
+    {query.length == 0 && <h1>All posts</h1>}
+    {(posts?.length ?? 0) > 4 && <Pagination page={pageIndex} totalPages={totalPages} />}
+    <PostList posts={posts} />
+    <Pagination page={pageIndex} totalPages={totalPages}/>
+</BaseLayout>

--- a/src/pages/tagged/[tag].astro
+++ b/src/pages/tagged/[tag].astro
@@ -1,9 +1,9 @@
 ---
-import BaseLayout from '../../../layouts/base-layout.astro';
-import { supabase } from '../../../util/supabase.astro';
-import Pagination from '../../../components/pagination.astro';
-import PostList from '../../../components/post-list.astro';
-import Seo from '../../../components/seo.astro';
+import BaseLayout from '../../layouts/base-layout.astro';
+import { supabase } from '../../util/supabase.astro';
+import Pagination from '../../components/pagination.astro';
+import PostList from '../../components/post-list.astro';
+import Seo from '../../components/seo.astro';
 
 const err = (code: number) => {
     Astro.response.status = code;
@@ -12,13 +12,14 @@ const err = (code: number) => {
     return new Response(null, Astro.response);
 };
 
-const { tag, page: pageStr = '1' } = Astro.params;
+const { tag } = Astro.params;
+const pageStr = Astro.url.searchParams.get('p') ?? '1';
 
 if (!tag) {
     return err(404);
 }
 
-const page = parseInt(pageStr) - 1;
+const pageIndex = (parseInt(pageStr) || 1) - 1;
 
 const RESULTS_PER_PAGE = 20;
 
@@ -29,8 +30,8 @@ const { data: posts, error: postsError } = await supabase()
     .contains('tags', [tag])
     .order('created_at', { ascending: false })
     .range(
-        page * RESULTS_PER_PAGE,
-        page * RESULTS_PER_PAGE + (RESULTS_PER_PAGE - 1)
+        pageIndex * RESULTS_PER_PAGE,
+        pageIndex * RESULTS_PER_PAGE + (RESULTS_PER_PAGE - 1)
     );
 
 const { count: total } = await supabase()
@@ -45,7 +46,7 @@ const totalPages = Math.ceil((total ?? 1) / RESULTS_PER_PAGE);
 <Seo description={`All posts tagged #${tag}`} />
 <BaseLayout title={`tagged "${tag}"`}>
     <h1>tagged "{tag}"</h1>
-    {(posts?.length ?? 0) > 4 && <Pagination tag={tag} page={page} totalPages={totalPages} />}
+    {(posts?.length ?? 0) > 4 && <Pagination page={pageIndex} totalPages={totalPages} />}
     <PostList posts={posts} />
-    <Pagination tag={tag} page={page} totalPages={totalPages} />
+    <Pagination page={pageIndex} totalPages={totalPages} />
 </BaseLayout>


### PR DESCRIPTION
Added basic search functionality. Currently it just looks for the entered search text in the title of posts, case insensitive. We probably want more robust search functionality down the line.

Also, refactored the pagination component to be page-agnostic and moved page number into a search parameter (e.g. `/tagged/thing/1` -> `/tagged/thing?p=1`), in order to be able to share it between the tagged search and post search.