### PR TITLE
Fixed tag links

### DIFF
--- a/src/components/tag-list.astro
+++ b/src/components/tag-list.astro
@@ -7,7 +7,7 @@ const { tags = [] } = Astro.props;
         <ul class="tagList">
             {tags.map((tag: string, i: number) => (
                 <span>
-                    <a class='tag' href={`/tagged/${tag}/1`}>#{tag}</a>
+                    <a class='tag' href={`/tagged/${tag}`}>#{tag}</a>
                 </span>
             ))}
         </ul>


### PR DESCRIPTION
New tag link format doesn't include the page number as part of the path