### PR TITLE
move SEO tags inside layout, fixing incorrect charset data

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { defineConfig, envField } from 'astro/config';
+import { defineConfig } from 'astro/config';
 
 import preact from '@astrojs/preact';
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,8 +3,8 @@ import Seo from '../components/seo.astro';
 import BaseLayout from '../layouts/base-layout.astro';
 ---
 
-<Seo title="About" description="hi it's markdump"/>
 <BaseLayout title="About">
+    <Seo title="About" description="hi it's markdump"/>
     <p>hi it's markdump</p>
     <p>the markdown hosting website</p>
     <p>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,8 +22,8 @@ const { data: latest, error } = await supabase()
     .limit(10);
 ---
 
-<Seo description="A simpler, better way to share markdown." />
 <BaseLayout>
+    <Seo description="A simpler, better way to share markdown." />
     <small>{phrase}</small>
     <hr />
     <h2>Latest posts</h2>

--- a/src/pages/new.astro
+++ b/src/pages/new.astro
@@ -4,8 +4,8 @@ import NewPostForm from '../components/new-post-form/new-post-form';
 import Seo from '../components/seo.astro';
 ---
 
-<Seo title="New Post"/>
 <BaseLayout title="New">
+    <Seo title="New Post"/>
     <h1>New post</h1>
     <NewPostForm client:load />
 </BaseLayout>

--- a/src/pages/posts/[postid].astro
+++ b/src/pages/posts/[postid].astro
@@ -43,9 +43,8 @@ const showCopyLinkWarning = Astro.url.searchParams.get('created') !== null;
 const url = Astro.url.href;
 ---
 
-<Seo title={content.title} description={trimmedText} />
 <BaseLayout title={`${content.title || 'Untitled'}`}>
-
+    <Seo title={content.title} description={trimmedText} />
     {showCopyLinkWarning && 
     <section class="attention">
         <div>

--- a/src/pages/search.astro
+++ b/src/pages/search.astro
@@ -39,8 +39,8 @@ const { count: total } = await supabase()
 const totalPages = Math.ceil((total ?? 1) / RESULTS_PER_PAGE);
 ---
 
-<Seo title='Markdump' description={`Search for ${query}`} />
 <BaseLayout title={`Search "${query}"`}>
+    <Seo title='Markdump' description={`Search for ${query}`} />
     {query.length > 0 && <h1>Search results for "{query}"</h1>}
     {query.length == 0 && <h1>All posts</h1>}
     {(posts?.length ?? 0) > 4 && <Pagination page={pageIndex} totalPages={totalPages} />}


### PR DESCRIPTION
this is really dumb.

the standard for choosing which charset to parse a document in only cares about `<meta charset="utf-8" />` if it's in the first 1024 bytes sent by the server; otherwise it defaults to choosing what it thinks is appropriate (kind of, it's a [little more involved than that](https://en.wikipedia.org/wiki/Character_encodings_in_HTML#Encoding_detection_algorithm)). 

the SEO tags were pushing the meta information in the head past the 1024 limit, meaning the browser was choosing incorrect encoding schemas. 

so the fix is to move SEO tags to either within the layout elements, or after them. doesn't matter which, the layout just needs to come first.

god i hate the internet